### PR TITLE
Delete posters

### DIFF
--- a/app/controllers/api/v1/posters_controller.rb
+++ b/app/controllers/api/v1/posters_controller.rb
@@ -3,4 +3,11 @@ class Api::V1::PostersController < ApplicationController
     posters = Poster.all
     render json: PosterSerializer.format_posters(posters)
   end
+
+
+
+
+  def destroy
+    render json: Poster.delete(params[:id])
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,5 +11,5 @@ Rails.application.routes.draw do
   get "/api/v1/posters", to: "api/v1/posters#index"
 
 
-  delete "/api/v1/posters", to: "api/v1/posters#destroy"
+  delete "/api/v1/posters/:id", to: "api/v1/posters#destroy"
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,4 +9,7 @@ Rails.application.routes.draw do
   # root "posts#index"
 
   get "/api/v1/posters", to: "api/v1/posters#index"
+
+
+  delete "/api/v1/posters", to: "api/v1/posters#destroy"
 end

--- a/spec/requests/api/v1/posters_request_spec.rb
+++ b/spec/requests/api/v1/posters_request_spec.rb
@@ -58,4 +58,43 @@ describe "Posters API", type: :request do
       expect(attributes[:img_url]).to be_a(String) 
     end
   end
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  it 'can destroy a poster' do
+    poster = Poster.create(name: "HOPELESSNESS",
+    description: "Stay in your comfort zone; it's safer.",
+    price: 112.00,
+    year: 2020,
+    vintage: true,
+    img_url: "./assets/hopelessness.jpg")
+
+    expect(Poster.count).to eq(1)
+
+    delete "/api/v1/posters/#{poster.id}"
+
+    expect(response).to be_successful
+    expect(Poster.count).to eq(0)
+
+    expect{Poster.find(poster.id) }.to raise_error(ActiveRecord::RecordNotFound)
+  end
 end


### PR DESCRIPTION
This branch adds functionality to make HTTP delete requests, allowing users to delete posters by the poster id. This functionality is tested in the spec file and all tests pass.